### PR TITLE
feat: add support for unwatching

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## Documentation
 
-Visit: [https://docs.plasmo.com/framework/storage](https://docs.plasmo.com/framework/storage)
+Visit: [https://docs.plasmo.com/framework-api/storage](https://docs.plasmo.com/framework-api/storage)
 
 ## Usage Examples
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -37,13 +37,14 @@ export const useStorage = <T = any>(
 
   useEffect(() => {
     isMounted.current = true
-    storageRef.current.watch({
+    const watchConfig = {
       [key]: (c) => {
         if (isMounted.current) {
           setRenderValue(c.newValue)
         }
       }
-    })
+    }
+    storageRef.current.watch(watchConfig)
 
     storageRef.current.get<T>(key).then(async (v) => {
       if (onInit instanceof Function) {
@@ -59,6 +60,7 @@ export const useStorage = <T = any>(
 
     return () => {
       isMounted.current = false
+      storageRef.current.unwatch(watchConfig)
     }
   }, [])
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -27,8 +27,34 @@ describe("react hook", () => {
 
     expect(localStorage.getItem(key)).toBe(JSON.stringify(value))
   })
+  test("removes watch listener when unmounting", () => {
+    const mockAttach = jest.fn()
+    const mockDetach = jest.fn()
+    global.chrome = {
+      storage: {
+        // @ts-ignore
+        onChanged: {
+          addListener: mockAttach,
+          removeListener: mockDetach
+        },
 
-  expect(localStorage.getItem(key)).toBe(JSON.stringify(value))
+        sync: {
+          // @ts-ignore
+          get: jest.fn()
+        }
+      }
+    }
+
+    const testRenderComponent = () => {
+      useStorage("test")
+      return null
+    }
+    const { unmount } = render(React.createElement(testRenderComponent))
+    unmount()
+
+    expect(mockAttach).toHaveBeenCalled()
+    expect(mockDetach).toHaveBeenCalled()
+  })
 })
 
 describe("watch/unwatch", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,14 +3,13 @@
  * Licensed under the MIT license.
  * This module share storage between chrome storage and local storage.
  */
-import { beforeEach, expect, test } from "@jest/globals"
+import { beforeEach, expect, jest, test } from "@jest/globals"
 import { act, renderHook } from "@testing-library/react"
 
-import { useStorage } from "~index"
-
-global.chrome = undefined
+import { Storage, StorageWatchListener, useStorage } from "~index"
 
 beforeEach(() => {
+  global.chrome = undefined
   localStorage.clear()
 })
 
@@ -26,4 +25,136 @@ test("stores basic text data ", () => {
   })
 
   expect(localStorage.getItem(key)).toBe(JSON.stringify(value))
+})
+
+test("attaches storage listener when watch listener is added", () => {
+  const mockAttach = jest.fn()
+  const mockDetach = jest.fn()
+  global.chrome = {
+    storage: {
+      // @ts-ignore
+      onChanged: {
+        addListener: mockAttach,
+        removeListener: mockDetach
+      }
+    }
+  }
+
+  const storage = new Storage()
+  storage.watch({ key: () => {} })
+
+  expect(mockAttach).toHaveBeenCalled()
+  expect(mockDetach).not.toHaveBeenCalled()
+})
+
+test("removes storage listener when all watch listener is removed", () => {
+  const mockAttach = jest.fn()
+  const mockDetach = jest.fn()
+  global.chrome = {
+    storage: {
+      // @ts-ignore
+      onChanged: {
+        addListener: mockAttach,
+        removeListener: mockDetach
+      }
+    }
+  }
+
+  const storage = new Storage()
+  const watchConfig = { key: () => {} }
+  storage.watch(watchConfig)
+  storage.unwatch(watchConfig)
+
+  expect(mockAttach).toHaveBeenCalled()
+  expect(mockDetach).toHaveBeenCalled()
+})
+
+test("doesn't remove storage listener when watch listener remain after unwatch", () => {
+  const mockAttach = jest.fn()
+  const mockDetach = jest.fn()
+  global.chrome = {
+    storage: {
+      // @ts-ignore
+      onChanged: {
+        addListener: mockAttach,
+        removeListener: mockDetach
+      }
+    }
+  }
+
+  const storage = new Storage()
+  const watchConfig = { key: () => {} }
+  storage.watch(watchConfig)
+  storage.watch({ key: () => {} })
+  storage.unwatch(watchConfig)
+
+  expect(mockAttach).toHaveBeenCalled()
+  expect(mockDetach).not.toHaveBeenCalled()
+})
+
+test("calls all watch listeners", () => {
+  let internalListener: StorageWatchListener = () => {}
+  global.chrome = {
+    storage: {
+      // @ts-ignore
+      onChanged: {
+        addListener: (listener) => {
+          internalListener = listener
+        },
+        removeListener: jest.fn()
+      }
+    }
+  }
+
+  const storage = new Storage()
+
+  const watchFn1 = jest.fn()
+  const watchFn2 = jest.fn()
+
+  storage.watch({ key: watchFn1 })
+  storage.watch({ key: watchFn2 })
+
+  internalListener(
+    {
+      key: { newValue: "{}", oldValue: "{}" }
+    } as chrome.storage.StorageChange,
+    "sync"
+  )
+
+  expect(watchFn1).toHaveBeenCalled()
+  expect(watchFn2).toHaveBeenCalled()
+})
+
+test("doesn't call unwatched listeners", () => {
+  let internalListener: StorageWatchListener = () => {}
+  global.chrome = {
+    storage: {
+      // @ts-ignore
+      onChanged: {
+        addListener: (listener) => {
+          internalListener = listener
+        },
+        removeListener: jest.fn()
+      }
+    }
+  }
+
+  const storage = new Storage()
+
+  const watchFn1 = jest.fn()
+  const watchFn2 = jest.fn()
+
+  storage.watch({ key: watchFn1 })
+  storage.watch({ key: watchFn2 })
+  storage.unwatch({ key: watchFn1 })
+
+  internalListener(
+    {
+      key: { newValue: "{}", oldValue: "{}" }
+    } as chrome.storage.StorageChange,
+    "sync"
+  )
+
+  expect(watchFn1).not.toHaveBeenCalled()
+  expect(watchFn2).toHaveBeenCalled()
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,8 +3,9 @@
  * Licensed under the MIT license.
  * This module share storage between chrome storage and local storage.
  */
-import { beforeEach, expect, jest, test } from "@jest/globals"
-import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, jest, test } from "@jest/globals"
+import { act, render, renderHook } from "@testing-library/react"
+import React from "react"
 
 import { Storage, StorageWatchListener, useStorage } from "~index"
 
@@ -13,148 +14,153 @@ beforeEach(() => {
   localStorage.clear()
 })
 
-test("stores basic text data ", () => {
-  const key = "test"
+describe("react hook", () => {
+  test("stores basic text data ", () => {
+    const key = "test"
 
-  const value = "hello world"
+    const value = "hello world"
 
-  const { result } = renderHook(() => useStorage(key))
+    const { result } = renderHook(() => useStorage(key))
+    act(() => {
+      result.current[1](value)
+    })
 
-  act(() => {
-    result.current[1](value)
+    expect(localStorage.getItem(key)).toBe(JSON.stringify(value))
   })
 
   expect(localStorage.getItem(key)).toBe(JSON.stringify(value))
 })
 
-test("attaches storage listener when watch listener is added", () => {
-  const mockAttach = jest.fn()
-  const mockDetach = jest.fn()
-  global.chrome = {
-    storage: {
-      // @ts-ignore
-      onChanged: {
-        addListener: mockAttach,
-        removeListener: mockDetach
+describe("watch/unwatch", () => {
+  test("attaches storage listener when watch listener is added", () => {
+    const mockAttach = jest.fn()
+    const mockDetach = jest.fn()
+    global.chrome = {
+      storage: {
+        // @ts-ignore
+        onChanged: {
+          addListener: mockAttach,
+          removeListener: mockDetach
+        }
       }
     }
-  }
 
-  const storage = new Storage()
-  storage.watch({ key: () => {} })
+    const storage = new Storage()
+    storage.watch({ key: () => {} })
 
-  expect(mockAttach).toHaveBeenCalled()
-  expect(mockDetach).not.toHaveBeenCalled()
-})
+    expect(mockAttach).toHaveBeenCalled()
+    expect(mockDetach).not.toHaveBeenCalled()
+  })
 
-test("removes storage listener when all watch listener is removed", () => {
-  const mockAttach = jest.fn()
-  const mockDetach = jest.fn()
-  global.chrome = {
-    storage: {
-      // @ts-ignore
-      onChanged: {
-        addListener: mockAttach,
-        removeListener: mockDetach
+  test("removes storage listener when all watch listener is removed", () => {
+    const mockAttach = jest.fn()
+    const mockDetach = jest.fn()
+    global.chrome = {
+      storage: {
+        // @ts-ignore
+        onChanged: {
+          addListener: mockAttach,
+          removeListener: mockDetach
+        }
       }
     }
-  }
 
-  const storage = new Storage()
-  const watchConfig = { key: () => {} }
-  storage.watch(watchConfig)
-  storage.unwatch(watchConfig)
+    const storage = new Storage()
+    const watchConfig = { key: () => {} }
+    storage.watch(watchConfig)
+    storage.unwatch(watchConfig)
 
-  expect(mockAttach).toHaveBeenCalled()
-  expect(mockDetach).toHaveBeenCalled()
-})
+    expect(mockAttach).toHaveBeenCalled()
+    expect(mockDetach).toHaveBeenCalled()
+  })
 
-test("doesn't remove storage listener when watch listener remain after unwatch", () => {
-  const mockAttach = jest.fn()
-  const mockDetach = jest.fn()
-  global.chrome = {
-    storage: {
-      // @ts-ignore
-      onChanged: {
-        addListener: mockAttach,
-        removeListener: mockDetach
+  test("doesn't remove storage listener when watch listener remain after unwatch", () => {
+    const mockAttach = jest.fn()
+    const mockDetach = jest.fn()
+    global.chrome = {
+      storage: {
+        // @ts-ignore
+        onChanged: {
+          addListener: mockAttach,
+          removeListener: mockDetach
+        }
       }
     }
-  }
 
-  const storage = new Storage()
-  const watchConfig = { key: () => {} }
-  storage.watch(watchConfig)
-  storage.watch({ key: () => {} })
-  storage.unwatch(watchConfig)
+    const storage = new Storage()
+    const watchConfig = { key: () => {} }
+    storage.watch(watchConfig)
+    storage.watch({ key: () => {} })
+    storage.unwatch(watchConfig)
 
-  expect(mockAttach).toHaveBeenCalled()
-  expect(mockDetach).not.toHaveBeenCalled()
-})
+    expect(mockAttach).toHaveBeenCalled()
+    expect(mockDetach).not.toHaveBeenCalled()
+  })
 
-test("calls all watch listeners", () => {
-  let internalListener: StorageWatchListener = () => {}
-  global.chrome = {
-    storage: {
-      // @ts-ignore
-      onChanged: {
-        addListener: (listener) => {
-          internalListener = listener
-        },
-        removeListener: jest.fn()
+  test("calls all watch listeners", () => {
+    let internalListener: StorageWatchListener = () => {}
+    global.chrome = {
+      storage: {
+        // @ts-ignore
+        onChanged: {
+          addListener: (listener) => {
+            internalListener = listener
+          },
+          removeListener: jest.fn()
+        }
       }
     }
-  }
 
-  const storage = new Storage()
+    const storage = new Storage()
 
-  const watchFn1 = jest.fn()
-  const watchFn2 = jest.fn()
+    const watchFn1 = jest.fn()
+    const watchFn2 = jest.fn()
 
-  storage.watch({ key: watchFn1 })
-  storage.watch({ key: watchFn2 })
+    storage.watch({ key: watchFn1 })
+    storage.watch({ key: watchFn2 })
 
-  internalListener(
-    {
-      key: { newValue: "{}", oldValue: "{}" }
-    } as chrome.storage.StorageChange,
-    "sync"
-  )
+    internalListener(
+      {
+        key: { newValue: "{}", oldValue: "{}" }
+      } as chrome.storage.StorageChange,
+      "sync"
+    )
 
-  expect(watchFn1).toHaveBeenCalled()
-  expect(watchFn2).toHaveBeenCalled()
-})
+    expect(watchFn1).toHaveBeenCalled()
+    expect(watchFn2).toHaveBeenCalled()
+  })
 
-test("doesn't call unwatched listeners", () => {
-  let internalListener: StorageWatchListener = () => {}
-  global.chrome = {
-    storage: {
-      // @ts-ignore
-      onChanged: {
-        addListener: (listener) => {
-          internalListener = listener
-        },
-        removeListener: jest.fn()
+  test("doesn't call unwatched listeners", () => {
+    let internalListener: StorageWatchListener = () => {}
+    global.chrome = {
+      storage: {
+        // @ts-ignore
+        onChanged: {
+          addListener: (listener) => {
+            internalListener = listener
+          },
+          removeListener: jest.fn()
+        }
       }
     }
-  }
 
-  const storage = new Storage()
+    const storage = new Storage()
 
-  const watchFn1 = jest.fn()
-  const watchFn2 = jest.fn()
+    const watchFn1 = jest.fn()
+    const watchFn2 = jest.fn()
 
-  storage.watch({ key: watchFn1 })
-  storage.watch({ key: watchFn2 })
-  storage.unwatch({ key: watchFn1 })
+    storage.watch({ key: watchFn1 })
+    storage.watch({ key: watchFn2 })
+    storage.unwatch({ key: watchFn1 })
 
-  internalListener(
-    {
-      key: { newValue: "{}", oldValue: "{}" }
-    } as chrome.storage.StorageChange,
-    "sync"
-  )
+    internalListener(
+      {
+        key: { newValue: "{}", oldValue: "{}" }
+      } as chrome.storage.StorageChange,
+      "sync"
+    )
 
-  expect(watchFn1).not.toHaveBeenCalled()
-  expect(watchFn2).toHaveBeenCalled()
+    expect(watchFn1).not.toHaveBeenCalled()
+    expect(watchFn2).toHaveBeenCalled()
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export class Storage {
     this.#secretSet = new Set(secretKeyList)
     this.#area = storageArea
 
-    if (!!chrome?.storage) {
+    if (chrome?.storage) {
       this.#client = chrome.storage[storageArea]
       this.hasExtensionAPI = true
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@ type StorageWatchEventListener = Parameters<
 >[0]
 
 export type StorageAreaName = Parameters<StorageWatchEventListener>[1]
+export type StorageWatchListener = (
+  c: chrome.storage.StorageChange,
+  area: StorageAreaName
+) => void
 
 const hasWindow = typeof window !== "undefined"
 
@@ -21,6 +25,8 @@ export class Storage {
   #client: chrome.storage.StorageArea = null
   #localClient = hasWindow ? window.localStorage : null
   #area: StorageAreaName = null
+  #watchListeners: Record<string, StorageWatchListener[]> = {}
+  #internalStorageListener: StorageWatchListener | null = null
 
   hasExtensionAPI = false
 
@@ -140,19 +146,28 @@ export class Storage {
       resolve(undefined)
     })
 
-  watch = (
-    callbackMap: Record<
-      string,
-      (c: chrome.storage.StorageChange, area: StorageAreaName) => void
-    >
-  ) =>
-    this.hasExtensionAPI &&
-    chrome.storage.onChanged.addListener((changes, areaName) => {
+  watch = (callbackMap: Record<string, StorageWatchListener>) => {
+    if (this.hasExtensionAPI) {
+      for (const [key, callback] of Object.entries(callbackMap)) {
+        if (!this.#watchListeners[key]) {
+          this.#watchListeners[key] = []
+        }
+        this.#watchListeners[key].push(callback)
+      }
+
+      if (this.#internalStorageListener === null) {
+        this.#attachInternalStorageListener()
+      }
+    }
+  }
+
+  #attachInternalStorageListener = () => {
+    this.#internalStorageListener = (changes, areaName) => {
       if (areaName !== this.#area) {
         return
       }
 
-      const callbackKeySet = new Set(Object.keys(callbackMap))
+      const callbackKeySet = new Set(Object.keys(this.#watchListeners))
       const changeKeys = Object.keys(changes)
 
       const relevantKeyList = changeKeys.filter((key) =>
@@ -164,15 +179,50 @@ export class Storage {
       }
 
       for (const key of relevantKeyList) {
-        callbackMap[key]?.(
-          {
-            newValue: this.#parseValue(changes[key].newValue),
-            oldValue: this.#parseValue(changes[key].oldValue)
-          },
-          areaName
+        this.#watchListeners[key]?.forEach((callback) =>
+          callback(
+            {
+              newValue: this.#parseValue(changes[key].newValue),
+              oldValue: this.#parseValue(changes[key].oldValue)
+            },
+            areaName
+          )
         )
       }
-    })
+    }
+
+    chrome.storage.onChanged.addListener(this.#internalStorageListener)
+  }
+
+  unwatch = (callbackMap: Record<string, StorageWatchListener>) => {
+    for (const [key, callback] of Object.entries(callbackMap)) {
+      if (!this.#watchListeners[key]) continue
+
+      this.#watchListeners[key] = this.#watchListeners[key].filter(
+        (cb) => cb !== callback
+      )
+
+      if (this.#watchListeners[key].length === 0) {
+        delete this.#watchListeners[key]
+      }
+    }
+
+    if (Object.keys(this.#watchListeners).length === 0) {
+      this.#detachInternalStorageListener()
+    }
+  }
+
+  unwatchAll = () => {
+    this.#watchListeners = {}
+    this.#detachInternalStorageListener()
+  }
+
+  #detachInternalStorageListener() {
+    if (this.#internalStorageListener !== null) {
+      chrome.storage.onChanged.removeListener(this.#internalStorageListener)
+      this.#internalStorageListener = null
+    }
+  }
 
   #parseValue(rawValue: any) {
     try {


### PR DESCRIPTION
Currently, the storage module only allows adding listeners using `watch(...)` but doesn't allow removing listeners once added.

This can result in a memory leak when using storage and the `useStorage` hook (or creating and deleting instances another way) as it leaves dangling `chrome.storage.onChanged` listeners attached - also resulting in the `Storage` instances never getting garbage collected.

This PR fixes this issue by allowing the code to `unwatch`, i.e. remove listeners.

# Changes

## `unwatch()`

The new `unwatch(...)` function can be called with the same arguments as `watch(...)` and will remove all provided listeners from the internal list

```TS
const watchConfig = {
    myKey: () => {
      // ...
    }
}
storage.watch(watchConfig)
// ..
storage.unwatch(watchConfig)
```

## `unwatchAll()`

Utility method to remove all listeners attached to the `Storage` instance and can act as a "destroy all" when trying to centrally clean up an instance.

## `isWatchingSupported()`

Currently, watching is not supported when using the `localStorage` fallback – though this could be implemented using the [`storage` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event). In order for scripts using this library to not depend on the implementation details of when and how `watch(...)` is supported, a helper method `isWatchingSupported()` is added which returns if the current environment supports it.

Currently, this is only a wrapper for `this.hasExtensionAPI` but this way, scripts will be future-proof by not relying on this behaviour.

## Return values

`watch(...)` and `unwatch(...)` will now return a boolean indicating the success of the operation. This can be used by scripts to use fallback methods instead of being unaware of changes.

```TS
const isWatching = storage.watch(...);
if (!isWatching) {
  // ... Use a fallback method like manually reading periodically
}
```

I don't know if this behavior is intuitive enough, so feedback is welcome.

## Internal refactoring

To enable unwatching changes, some refactoring of the listener system have been done.

First, listeners added with `watch(...)` will now be added to a private record `#watchListeners[keyName]` instead of adding a separate `chrome.storage.onChanged` listener for each call to `watch(...)`.

Instead, a central listener will be attached and stored under `this.#internalStorageListener` for reference. When no central listener exists yet, `#attachInternalStorageListener()` will be called to attach it.

When `unwatch(...)` detects that no listeners are left or when calling `unwatchAll(...)`, `#detachInternalStorageListener()` is called to remove the central listener to allow garbage collection.

## React hook

The React hook has been updated to automatically `unwatch` the keys to prevent memory leaks.

## Test cases

A few test cases have been added to verify that the listeners and react hook work as expected.