### PR TITLE
Refactoring the Storage constructor() to take in an object instead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ export type StorageCallbackMap = Record<string, StorageWatchCallback>
 
 const hasWindow = typeof window !== "undefined"
 
+export type StorageConfig = {
+  storageArea: StorageAreaName,
+  secretKeyList: string[] 
+}
+
 /**
  * https://docs.plasmo.com/framework-api/storage
  */
@@ -38,10 +43,12 @@ export class Storage {
 
   hasExtensionAPI = false
 
-  constructor(
-    storageArea = "sync" as StorageAreaName,
-    secretKeyList: string[] = []
-  ) {
+  constructor(config: StorageConfig = {
+    storageArea: "sync" as StorageAreaName,
+    secretKeyList: []
+  }) {
+    const {storageArea, secretKeyList} = config;
+    
     this.#secretSet = new Set(secretKeyList)
     this.#area = storageArea
 


### PR DESCRIPTION
Note: This would be a breaking change and require updating the version and the docs.

Currently, the constructor of `Storage` required you to pass arguments:

```
const storage = new Storage('sync', ['accessToken']);
```

It's likely cleaner to make it an object, so you can do something like:
```
const storage = new Storage({
  secretKeyList: [...]
})
```

