### PR TITLE
Migrate to webextension-polyfill (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@
 
 Visit: [https://docs.plasmo.com/framework-api/storage](https://docs.plasmo.com/framework-api/storage)
 
+## Firefox
+
+To use the storage API on Firefox during development you need to add an addon ID to your manifest, otherwise you will get this error:
+
+> Error: The storage API will not work with a temporary addon ID. Please add an explicit addon ID to your manifest. For more information see https://mzl.la/3lPk1aE.
+
+To add an addon ID to your manifest, add this to your package.json:
+
+```JSON
+"manifest": {
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "your-id@example.com"
+    }
+  }
+}
+```
+
+During development, you may use any ID. If you have published your extension, you can use the ID assigned by Mozilla Addons.
+
 ## Usage Examples
 
 - [MICE](https://github.com/PlasmoHQ/mice)

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/chrome": "0.0.195",
     "@types/node": "18.7.8",
     "@types/react": "18.0.17",
+    "@types/webextension-polyfill": "0.9.0",
     "cross-env": "7.0.3",
     "jest": "28.1.3",
     "jest-environment-jsdom": "28.1.3",
@@ -65,5 +66,8 @@
     "ts-jest": "28.0.8",
     "tsup": "6.2.2",
     "typescript": "4.7.4"
+  },
+  "dependencies": {
+    "webextension-polyfill": "0.10.0"
   }
 }


### PR DESCRIPTION
This PR migrates the package to the webextension-polyfill package to make it compatible with Firefox.

The package is used to not produce additional overhead by needing to use `if (isChrome) ... else ...` for every API call and instead using the unified, promise-based API provided by the polyfill.

The storage package API remains unchanged, so packages using this project don't need to update their code to support Firefox. A small info about adding an addon ID for Firefox was added to the README - if merged, this should be added to the docs.