### PR TITLE
feat: option to treat all keys as secret

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,7 +5,6 @@
 const config = {
   clearMocks: true,
   testEnvironment: "jsdom",
-  moduleFileExtensions: ["js", "ts"],
   extensionsToTreatAsEsm: [".ts"],
   globals: {
     chrome: {
@@ -15,7 +14,13 @@ const config = {
     }
   },
   transform: {
-    "^.+.ts?$": ["ts-jest", { isolatedModules: true, useESM: true }]
+    "^.+.ts?$": [
+      "ts-jest",
+      {
+        useESM: true,
+        isolatedModules: true
+      }
+    ]
   },
   testMatch: ["**/*.test.ts"],
   verbose: true,

--- a/src/get-quota-warning.ts
+++ b/src/get-quota-warning.ts
@@ -1,0 +1,60 @@
+import type { InternalStorage, StorageArea, StorageAreaName } from "~index"
+
+// https://stackoverflow.com/a/23329386/3151192
+function byteLengthCharCode(str: string) {
+  // returns the byte length of an utf8 string
+  let s = str.length
+  for (var i = str.length - 1; i >= 0; i--) {
+    const code = str.charCodeAt(i)
+    if (code > 0x7f && code <= 0x7ff) s++
+    else if (code > 0x7ff && code <= 0xffff) s += 2
+    if (code >= 0xdc00 && code <= 0xdfff) i-- //trail surrogate
+  }
+  return s
+}
+
+export const getQuotaWarning = async (
+  area: StorageAreaName,
+  storage: InternalStorage,
+  key: string,
+  value: string
+) => {
+  let warning = ""
+
+  checkQuota: if (area !== "managed") {
+    // Explicit access to the un-polyfilled version is used here
+    // as the polyfill might override the non-existent function
+    if (!chrome?.storage?.[area].getBytesInUse) {
+      break checkQuota
+    }
+
+    const client = storage[area] as StorageArea
+
+    // Firefox doesn't support quota bytes so the defined value at
+    // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/sync#storage_quotas_for_sync_data
+    // is used
+    const quota: number = client["QUOTA_BYTES"] || 102400
+
+    const newValueByteSize = byteLengthCharCode(value)
+    const [byteInUse, oldValueByteSize] = await Promise.all([
+      client.getBytesInUse(),
+      client.getBytesInUse(key)
+    ])
+
+    const newByteInUse = byteInUse + newValueByteSize - oldValueByteSize
+
+    // if used 80% of quota, show warning
+    const usedPercentage = newByteInUse / quota
+    if (usedPercentage > 0.8) {
+      warning = `Storage quota is almost full. ${newByteInUse}/${quota}, ${
+        usedPercentage * 100
+      }%`
+    }
+
+    if (usedPercentage > 1.0) {
+      throw new Error(`ABORTED - New value would exceed storage quota.`)
+    }
+  }
+
+  return warning
+}

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -37,7 +37,7 @@ export const useStorage = <T = any>(
   const storageRef = useRef(
     new Storage({
       area: isStringKey ? "sync" : rawKey.area,
-      secretKeyList: !isStringKey && rawKey.isSecret ? [key] : []
+      allSecret: !isStringKey && rawKey.isSecret
     })
   )
 
@@ -61,7 +61,6 @@ export const useStorage = <T = any>(
         }
         return
       }
-
       setRenderValue(v !== undefined ? v : onInit)
     })
 
@@ -79,10 +78,12 @@ export const useStorage = <T = any>(
 
   // Store the value into chrome storage, then set its render state
   const persistValue = useCallback(
-    (newValue: T) =>
-      setStoreValue(newValue).then(
-        () => isMounted.current && setRenderValue(newValue)
-      ),
+    async (newValue: T) => {
+      await setStoreValue(newValue)
+      if (isMounted.current) {
+        setRenderValue(newValue)
+      }
+    },
     [setStoreValue]
   )
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,12 +53,13 @@ const createStorageMock = ({ getTriggers = false } = {}) => {
 }
 
 describe("react hook", () => {
-  test("stores basic text data ", async () => {
+  test.only("stores basic text data ", async () => {
     const key = "test"
 
     const value = "hello world"
 
     const { result, unmount } = renderHook(() => useStorage(key))
+
     await act(async () => {
       await result.current[1](value)
     })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,7 +53,7 @@ const createStorageMock = ({ getTriggers = false } = {}) => {
 }
 
 describe("react hook", () => {
-  test.only("stores basic text data ", async () => {
+  test("stores basic text data ", async () => {
     const key = "test"
 
     const value = "hello world"

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,18 +88,20 @@ export class Storage {
     return value !== previousValue
   }
 
-  // If chrome storage is not available, use localStorage
-  // TODO: TRY asking for storage permission and retry?
-  #getValue = async (key: string) =>
-    this.hasExtensionAPI
-      ? this.#client.get(key).then((s) => s[key])
-      : this.#localClient?.getItem(key)
-
   /**
    * Get value from either local storage or chrome storage.
    */
-  get = async <T = string>(key: string) =>
-    this.#parseValue(await this.#getValue(key)) as T
+  get = async <T = string>(key: string) => {
+    if (this.hasExtensionAPI) {
+      const dataMap = await this.#client.get(key)
+      return this.#parseValue(dataMap[key]) as T
+    } else {
+      // If chrome storage is not available, use localStorage
+      // TODO: TRY asking for storage permission and retry?
+      const storedValue = this.#localClient?.getItem(key)
+      return this.#parseValue(storedValue) as T
+    }
+  }
 
   /**
    * Set the value. If it is a secret, it will only be set in extension storage.


### PR DESCRIPTION
This PR allows users to treat all keys in storage as secret keys (no syncing between localStorage and browser storage).

**Example**

```ts
const storage = new Storage({
  // set "secretKeyList" to "true" instead of an Array to 
  // treat all keys as secrets automatically
  secretKeyList: true
});
```