### PR TITLE
React `useState` style callback support for setting a new value

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -79,10 +79,18 @@ export const useStorage = <T = any>(
 
   // Store the value into chrome storage, then set its render state
   const persistValue = useCallback(
-    (newValue: T) =>
-      setStoreValue(newValue).then(
-        () => isMounted.current && setRenderValue(newValue)
-      ),
+    async (newValue: T | ((oldValue?: T) => T | Promise<T>)) => {
+      if (typeof newValue === "function") {
+        // @ts-expect-error | This will flag it as
+        // an error as the compiler doesn't know
+        // the type of "T"
+        newValue = await newValue(renderValue)
+      }
+
+      await setStoreValue(newValue as T)
+
+      return isMounted.current && setRenderValue(newValue as T)
+    },
     [setStoreValue]
   )
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -7,13 +7,15 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { Storage, StorageAreaName, StorageCallbackMap } from "./index"
 
+type Setter<T> = ((v?: T) => T) | T
+
 /**
  * https://docs.plasmo.com/framework-api/storage
  * @param rawKey
  * @param onInit  If it is a function, the returned value will be rendered and persisted. If it is a static value, it will only be rendered, not persisted
  * @returns
  */
-export const useStorage = <T extends any, Setter extends ((v?: T) => T) | T>(
+export const useStorage = <T = any>(
   rawKey:
     | string
     | {
@@ -21,7 +23,7 @@ export const useStorage = <T extends any, Setter extends ((v?: T) => T) | T>(
         area?: StorageAreaName
         isSecret?: boolean
       },
-  onInit?: Setter
+  onInit?: Setter<T>
 ) => {
   const isStringKey = typeof rawKey === "string"
 
@@ -78,9 +80,8 @@ export const useStorage = <T extends any, Setter extends ((v?: T) => T) | T>(
 
   // Store the value into chrome storage, then set its render state
   const persistValue = useCallback(
-    async (setter: Setter) => {
-      const newValue =
-        typeof setter === "function" ? setter(renderValue) : setter
+    async (setter: Setter<T>) => {
+      const newValue = setter instanceof Function ? setter(renderValue) : setter
 
       await setStoreValue(newValue)
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -70,6 +70,26 @@ describe("react hook", () => {
     unmount()
   })
 
+  test("mutate with setter function ", async () => {
+    const key = "test"
+
+    const value = "hello"
+
+    const setter = (prev: string) => prev + " world"
+
+    const { result, unmount } = renderHook(() => useStorage(key, value))
+
+    await act(async () => {
+      await result.current[1](setter)
+    })
+
+    const newValue = setter(value)
+
+    expect(result.current[0]).toBe(newValue)
+    expect(localStorage.getItem(key)).toBe(JSON.stringify(newValue))
+    unmount()
+  })
+
   test("removes watch listener when unmounting", () => {
     const { addListener, removeListener } = createStorageMock()
 


### PR DESCRIPTION
Allow the `useStorage` hook `persistValue` to support React `useState` style callback to set a new value.

**Example**

```ts
const [_, setExample] = useStorage("example_key");

setExample(async (oldValue) => ({
  ...oldValue,
  newKey: await someAsyncFunction()
}));
```