### PR TITLE
fix: Storage.prototype.remove and Storage.prototype.removeAll to handle namespace correctly 

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,7 +5,7 @@
 const config = {
   clearMocks: true,
   testEnvironment: "jsdom",
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.mjs"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.mts"],
   extensionsToTreatAsEsm: [".ts"],
   globals: {
     chrome: {

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -5,6 +5,7 @@
 const config = {
   clearMocks: true,
   testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.mjs"],
   extensionsToTreatAsEsm: [".ts"],
   globals: {
     chrome: {

--- a/jest.setup.mjs
+++ b/jest.setup.mjs
@@ -1,0 +1,72 @@
+// @ts-check
+import { jest } from "@jest/globals"
+
+/**
+ * Mimic the webcrypto API without implementing the actual encryption
+ * algorithms. Only the mock implementations used by the SecureStorage
+ */
+export const cryptoMock = {
+  subtle: {
+    importKey: jest.fn(),
+    deriveKey: jest.fn(),
+    decrypt: jest.fn(),
+    encrypt: jest.fn(),
+    digest: jest.fn()
+  },
+  getRandomValues: jest.fn()
+}
+
+cryptoMock.subtle.importKey.mockImplementation(
+  (format, keyData, algorithm, extractable, keyUsages) => {
+    return Promise.resolve({
+      format,
+      keyData,
+      algorithm,
+      extractable,
+      keyUsages
+    })
+  }
+)
+
+cryptoMock.subtle.deriveKey.mockImplementation(
+  (algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages) => {
+    return Promise.resolve({
+      algorithm,
+      baseKey,
+      derivedKeyAlgorithm,
+      extractable,
+      keyUsages
+    })
+  }
+)
+
+cryptoMock.subtle.decrypt.mockImplementation((algorithm, key, data) => {
+  // @ts-ignore
+  return Promise.resolve(new Uint8Array(data))
+})
+
+cryptoMock.subtle.encrypt.mockImplementation((algorithm, key, data) => {
+  // @ts-ignore
+  return Promise.resolve(new Uint8Array(data))
+})
+
+cryptoMock.subtle.digest.mockImplementation((algorithm, data) => {
+  return Promise.resolve(new Uint8Array([0x01, 0x02, 0x03, 0x04]))
+})
+
+cryptoMock.getRandomValues.mockImplementation((array) => {
+  // @ts-ignore
+  for (let i = 0; i < array.length; i++) {
+    // @ts-ignore
+    array[i] = Math.floor(Math.random() * 256)
+  }
+  return array
+})
+
+// The globalThis does not define crypto by default
+Object.defineProperty(globalThis, "crypto", {
+  value: cryptoMock,
+  writable: true,
+  enumerable: true,
+  configurable: true
+})

--- a/jest.setup.mts
+++ b/jest.setup.mts
@@ -1,4 +1,3 @@
-// @ts-check
 import { jest } from "@jest/globals"
 
 /**
@@ -40,24 +39,20 @@ cryptoMock.subtle.deriveKey.mockImplementation(
   }
 )
 
-cryptoMock.subtle.decrypt.mockImplementation((algorithm, key, data) => {
-  // @ts-ignore
+cryptoMock.subtle.decrypt.mockImplementation((_, __, data: ArrayBufferLike) => {
   return Promise.resolve(new Uint8Array(data))
 })
 
-cryptoMock.subtle.encrypt.mockImplementation((algorithm, key, data) => {
-  // @ts-ignore
+cryptoMock.subtle.encrypt.mockImplementation((_, __, data: ArrayBufferLike) => {
   return Promise.resolve(new Uint8Array(data))
 })
 
-cryptoMock.subtle.digest.mockImplementation((algorithm, data) => {
+cryptoMock.subtle.digest.mockImplementation((_, __) => {
   return Promise.resolve(new Uint8Array([0x01, 0x02, 0x03, 0x04]))
 })
 
-cryptoMock.getRandomValues.mockImplementation((array) => {
-  // @ts-ignore
+cryptoMock.getRandomValues.mockImplementation((array: Array<any>) => {
   for (let i = 0; i < array.length; i++) {
-    // @ts-ignore
     array[i] = Math.floor(Math.random() * 256)
   }
   return array

--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
   "devDependencies": {
     "@jest/globals": "29.5.0",
     "@jest/types": "29.5.0",
-    "@plasmohq/prettier-plugin-sort-imports": "latest",
-    "@plasmohq/rps": "latest",
+    "@plasmohq/prettier-plugin-sort-imports": "workspace:*",
+    "@plasmohq/rps": "workspace:*",
     "@testing-library/react": "14.0.0",
     "@types/chrome": "0.0.235",
     "@types/node": "18.16.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasmohq/storage",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Safely and securely store data and share them across your extension and websites",
   "type": "module",
   "module": "./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -124,8 +124,8 @@
   "devDependencies": {
     "@jest/globals": "29.5.0",
     "@jest/types": "29.5.0",
-    "@plasmohq/prettier-plugin-sort-imports": "workspace:*",
-    "@plasmohq/rps": "workspace:*",
+    "@plasmohq/prettier-plugin-sort-imports": "latest",
+    "@plasmohq/rps": "latest",
     "@testing-library/react": "14.0.0",
     "@types/chrome": "0.0.235",
     "@types/node": "18.16.3",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,13 +13,19 @@ const { useStorage } = await import("~hook")
 
 const mockStorage = {
   data: {},
-  get(key: string) {
+  get(key?: string) {
+    if (!key) {
+      return {...this.data}
+    }
     return {
       [key]: this.data[key]
     }
   },
   set(key = "", value = "") {
     this.data[key] = value
+  },
+  remove(key: string) {
+    delete this.data[key]
   },
   clear() {
     this.data = {}
@@ -38,7 +44,8 @@ const createStorageMock = () => {
     addListener: jest.fn(),
     removeListener: jest.fn(),
     getTriggers: jest.fn(),
-    setTriggers: jest.fn()
+    setTriggers: jest.fn(),
+    removeTriggers: jest.fn(),
   }
 
   const storage: typeof chrome.storage = {
@@ -63,7 +70,7 @@ const createStorageMock = () => {
           Object.entries(changes).forEach(([key, value]) => {
             mockStorage.set(key, value)
 
-            onChangedCallback(
+            onChangedCallback && onChangedCallback(
               {
                 [key]: {
                   oldValue: undefined,
@@ -73,6 +80,22 @@ const createStorageMock = () => {
               "sync"
             )
           })
+        }
+      ),
+      //@ts-ignore
+      remove: mockOutput.removeTriggers.mockImplementation(
+        (key: string) => {
+          mockStorage.remove(key)
+
+          onChangedCallback && onChangedCallback(
+            {
+              [key]: {
+                oldValue: mockStorage.data[key],
+                newValue: undefined
+              }
+            },
+            "sync"
+          )
         }
       )
     }
@@ -220,3 +243,107 @@ describe("watch/unwatch", () => {
     expect(storageMock.removeListener).toHaveBeenCalled()
   })
 })
+
+// Create a new describe block for CRUD operations with namespace
+describe("Storage - Basic CRUD operations with namespace", () => {
+  // Declare the storage and namespace variables
+  let storage = new Storage();
+  let storageMock: ReturnType<typeof createStorageMock>;
+  const namespace = "testNamespace:";
+
+  // Initialize storage and storageMock before each test case
+  beforeEach(() => {
+    storageMock = createStorageMock();
+    storage = new Storage();
+    storage.setNamespace(namespace);
+  });
+
+  // Test set operation with namespace
+  test("set operation", async () => {
+    // Test data
+    const testKey = "key";
+    const testValue = "value";
+
+    // Perform set operation
+    await storage.set(testKey, testValue);
+
+    // Check if storageMock.setTriggers is called with the correct parameters
+    expect(storageMock.setTriggers).toHaveBeenCalledWith({
+      [`${namespace}${testKey}`]: JSON.stringify(testValue)
+    });
+  });
+
+  // Test get operation with namespace
+  test("get operation", async () => {
+    // Test data
+    const testKey = "key";
+    const testValue = "value";
+
+    // Perform set operation
+    await storage.set(testKey, testValue);
+
+    // Perform get operation
+    const getValue = await storage.get(testKey);
+
+    // Check if storageMock.getTriggers is called with the correct parameter
+    expect(storageMock.getTriggers).toHaveBeenCalledWith(`${namespace}${testKey}`);
+
+    // Check if the returned value is correct
+    expect(getValue).toEqual(testValue);
+  });
+
+  // Test getAll operation with namespace
+  test("getAll operation", async () => {
+    // Test data
+    const testKey1 = "key1";
+    const testValue1 = "value1";
+    const testKey2 = "key2";
+    const testValue2 = "value2";
+
+    // Perform set operations for two keys
+    await storage.set(testKey1, testValue1);
+    await storage.set(testKey2, testValue2);
+
+    // Perform getAll operation
+    const allData = await storage.getAll();
+
+    // Check if the returned object has the correct keys 
+    // and ensure the keys are without namespace
+    expect(Object.keys(allData)).toEqual([testKey1, testKey2]);
+  });
+
+  // Test remove operation with namespace
+  test("remove operation", async () => {
+    // Test data
+    const testKey = "key";
+    const testValue = "value";
+
+    // Perform set operation
+    await storage.set(testKey, testValue);
+
+    // Perform remove operation
+    await storage.remove(testKey);
+
+    // Check if storageMock.removeListener is called with the correct parameter
+    expect(storageMock.removeTriggers).toHaveBeenCalledWith(`${namespace}${testKey}`);
+  });
+
+  // Test removeAll operation with namespace
+  test("removeAll operation", async () => {
+    // Test data
+    const testKey1 = "key1";
+    const testValue1 = "value1";
+    const testKey2 = "key2";
+    const testValue2 = "value2";
+
+    // Perform set operations for two keys
+    await storage.set(testKey1, testValue1);
+    await storage.set(testKey2, testValue2);
+
+    // Perform removeAll operation
+    await storage.removeAll();
+
+    expect(storageMock.removeTriggers).toHaveBeenCalledWith(`${namespace}${testKey1}`);
+    expect(storageMock.removeTriggers).toHaveBeenCalledWith(`${namespace}${testKey2}`);
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,7 +15,7 @@ const mockStorage = {
   data: {},
   get(key?: string) {
     if (!key) {
-      return {...this.data}
+      return { ...this.data }
     }
     return {
       [key]: this.data[key]
@@ -37,15 +37,23 @@ beforeEach(() => {
   jest.fn().mockReset()
 })
 
-const createStorageMock = () => {
+export const createStorageMock = (): {
+  mockStorage: typeof mockStorage
+  addListener: jest.Mock
+  removeListener: jest.Mock
+  getTriggers: jest.Mock
+  setTriggers: jest.Mock
+  removeTriggers: jest.Mock
+} => {
   let onChangedCallback: StorageWatchEventListener
 
   const mockOutput = {
+    mockStorage,
     addListener: jest.fn(),
     removeListener: jest.fn(),
     getTriggers: jest.fn(),
     setTriggers: jest.fn(),
-    removeTriggers: jest.fn(),
+    removeTriggers: jest.fn()
   }
 
   const storage: typeof chrome.storage = {
@@ -70,24 +78,25 @@ const createStorageMock = () => {
           Object.entries(changes).forEach(([key, value]) => {
             mockStorage.set(key, value)
 
-            onChangedCallback && onChangedCallback(
-              {
-                [key]: {
-                  oldValue: undefined,
-                  newValue: value
-                }
-              },
-              "sync"
-            )
+            onChangedCallback &&
+              onChangedCallback(
+                {
+                  [key]: {
+                    oldValue: undefined,
+                    newValue: value
+                  }
+                },
+                "sync"
+              )
           })
         }
       ),
       //@ts-ignore
-      remove: mockOutput.removeTriggers.mockImplementation(
-        (key: string) => {
-          mockStorage.remove(key)
+      remove: mockOutput.removeTriggers.mockImplementation((key: string) => {
+        mockStorage.remove(key)
 
-          onChangedCallback && onChangedCallback(
+        onChangedCallback &&
+          onChangedCallback(
             {
               [key]: {
                 oldValue: mockStorage.data[key],
@@ -96,8 +105,7 @@ const createStorageMock = () => {
             },
             "sync"
           )
-        }
-      )
+      })
     }
   }
 
@@ -247,103 +255,111 @@ describe("watch/unwatch", () => {
 // Create a new describe block for CRUD operations with namespace
 describe("Storage - Basic CRUD operations with namespace", () => {
   // Declare the storage and namespace variables
-  let storage = new Storage();
-  let storageMock: ReturnType<typeof createStorageMock>;
-  const namespace = "testNamespace:";
+  let storage = new Storage()
+  let storageMock: ReturnType<typeof createStorageMock>
+  const namespace = "testNamespace:"
 
   // Initialize storage and storageMock before each test case
   beforeEach(() => {
-    storageMock = createStorageMock();
-    storage = new Storage();
-    storage.setNamespace(namespace);
-  });
+    storageMock = createStorageMock()
+    storage = new Storage()
+    storage.setNamespace(namespace)
+  })
 
   // Test set operation with namespace
   test("set operation", async () => {
     // Test data
-    const testKey = "key";
-    const testValue = "value";
+    const testKey = "key"
+    const testValue = "value"
 
     // Perform set operation
-    await storage.set(testKey, testValue);
+    await storage.set(testKey, testValue)
 
     // Check if storageMock.setTriggers is called with the correct parameters
     expect(storageMock.setTriggers).toHaveBeenCalledWith({
       [`${namespace}${testKey}`]: JSON.stringify(testValue)
-    });
-  });
+    })
+  })
 
   // Test get operation with namespace
   test("get operation", async () => {
     // Test data
-    const testKey = "key";
-    const testValue = "value";
+    const testKey = "key"
+    const testValue = "value"
 
     // Perform set operation
-    await storage.set(testKey, testValue);
+    await storage.set(testKey, testValue)
 
     // Perform get operation
-    const getValue = await storage.get(testKey);
+    const getValue = await storage.get(testKey)
 
     // Check if storageMock.getTriggers is called with the correct parameter
-    expect(storageMock.getTriggers).toHaveBeenCalledWith(`${namespace}${testKey}`);
+    expect(storageMock.getTriggers).toHaveBeenCalledWith(
+      `${namespace}${testKey}`
+    )
 
     // Check if the returned value is correct
-    expect(getValue).toEqual(testValue);
-  });
+    expect(getValue).toEqual(testValue)
+  })
 
   // Test getAll operation with namespace
   test("getAll operation", async () => {
     // Test data
-    const testKey1 = "key1";
-    const testValue1 = "value1";
-    const testKey2 = "key2";
-    const testValue2 = "value2";
+    const testKey1 = "key1"
+    const testValue1 = "value1"
+    const testKey2 = "key2"
+    const testValue2 = "value2"
 
     // Perform set operations for two keys
-    await storage.set(testKey1, testValue1);
-    await storage.set(testKey2, testValue2);
+    await storage.set(testKey1, testValue1)
+    await storage.set(testKey2, testValue2)
 
     // Perform getAll operation
-    const allData = await storage.getAll();
+    const allData = await storage.getAll()
 
-    // Check if the returned object has the correct keys 
+    // Check if the returned object has the correct keys
     // and ensure the keys are without namespace
-    expect(Object.keys(allData)).toEqual([testKey1, testKey2]);
-  });
+    expect(Object.keys(allData)).toEqual([testKey1, testKey2])
+  })
 
   // Test remove operation with namespace
   test("remove operation", async () => {
     // Test data
-    const testKey = "key";
-    const testValue = "value";
+    const testKey = "key"
+    const testValue = "value"
 
     // Perform set operation
-    await storage.set(testKey, testValue);
+    await storage.set(testKey, testValue)
 
     // Perform remove operation
-    await storage.remove(testKey);
+    await storage.remove(testKey)
 
     // Check if storageMock.removeListener is called with the correct parameter
-    expect(storageMock.removeTriggers).toHaveBeenCalledWith(`${namespace}${testKey}`);
-  });
+    expect(storageMock.removeTriggers).toHaveBeenCalledWith(
+      `${namespace}${testKey}`
+    )
+  })
 
   // Test removeAll operation with namespace
   test("removeAll operation", async () => {
     // Test data
-    const testKey1 = "key1";
-    const testValue1 = "value1";
-    const testKey2 = "key2";
-    const testValue2 = "value2";
+    const testKey1 = "key1"
+    const testValue1 = "value1"
+    const testKey2 = "key2"
+    const testValue2 = "value2"
 
     // Perform set operations for two keys
-    await storage.set(testKey1, testValue1);
-    await storage.set(testKey2, testValue2);
+    await storage.set(testKey1, testValue1)
+    await storage.set(testKey2, testValue2)
 
     // Perform removeAll operation
-    await storage.removeAll();
+    await storage.removeAll()
 
-    expect(storageMock.removeTriggers).toHaveBeenCalledWith(`${namespace}${testKey1}`);
-    expect(storageMock.removeTriggers).toHaveBeenCalledWith(`${namespace}${testKey2}`);
-  });
-});
+    expect(storageMock.removeTriggers).toHaveBeenCalledWith(
+      `${namespace}${testKey1}`
+    )
+    expect(storageMock.removeTriggers).toHaveBeenCalledWith(
+      `${namespace}${testKey2}`
+    )
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,7 +330,6 @@ export abstract class BaseStorage {
    */
   abstract set: (key: string, rawValue: any) => Promise<string>
 
-
   abstract remove: (key: string) => Promise<void>
 
   /**

--- a/src/secure.test.ts
+++ b/src/secure.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, jest, test } from "@jest/globals"
+
+import { createStorageMock } from "~index.test"
+
+import { SecureStorage } from "./secure"
+
+const createEncoderMock = () => {
+  const mockFns = {
+    encode: jest.fn(),
+    decode: jest.fn()
+  }
+
+  // @ts-ignore
+  globalThis.TextEncoder = jest.fn().mockImplementation(() => ({
+    encode: mockFns.encode
+  }))
+
+  // @ts-ignore
+  globalThis.TextDecoder = jest.fn().mockImplementation(() => ({
+    decode: mockFns.decode
+  }))
+
+  mockFns.encode.mockImplementation((data: string) => {
+    return new Uint8Array(data.split("").map((c) => c.charCodeAt(0)))
+  })
+
+  mockFns.decode.mockImplementation((data: Uint8Array) => {
+    return data.reduce((acc, c) => acc + String.fromCharCode(c), "")
+  })
+
+  return mockFns
+}
+
+/**
+ * This test case only covers interface of the function
+ * and does not test the actual encryption/decryption.
+ */
+describe("SecureStorage - Basic CRUD", () => {
+  let storageMock: ReturnType<typeof createStorageMock>
+  beforeEach(() => {
+    storageMock?.mockStorage.clear()
+    jest.clearAllMocks()
+    createEncoderMock()
+  })
+
+  test("should properly set and get data", async () => {
+    const storageMock = createStorageMock()
+
+    const secureStorage = new SecureStorage({ area: "sync" })
+    await secureStorage.setPassword("testPassword")
+
+    await secureStorage.set("testKey", "mockData")
+
+    expect(storageMock.setTriggers).toHaveBeenCalledTimes(1)
+
+    const result = await secureStorage.get("testKey")
+
+    expect(storageMock.getTriggers).toHaveBeenCalledTimes(1)
+
+    // Assert that the decrypted data is returned
+    expect(result).toEqual("mockData")
+  })
+
+  test("should properly remove data", async () => {
+    const storageMock = createStorageMock()
+
+    // Initialize SecureStorage instance and set the password
+    const secureStorage = new SecureStorage({ area: "sync" })
+    await secureStorage.setPassword("testPassword")
+
+    // Test the 'remove' method
+    await secureStorage.remove("testKey")
+
+    // Assert that the underlying storage layer is called with the correct arguments
+    expect(storageMock.removeTriggers).toHaveBeenCalledTimes(1)
+
+    // Empty implies that correct key is used behind the scenes
+    // as the storage mock checks for the key before removing it
+    expect(storageMock.mockStorage.data).toEqual({})
+  })
+})

--- a/src/secure.ts
+++ b/src/secure.ts
@@ -23,7 +23,7 @@ const DEFAULT_SALT_SIZE = 16
 const DEFAULT_IV_SIZE = 32
 const DEFAULT_NS_SIZE = 8
 
-const DEFAULT_NS_SEPARATOR = "|:|"
+export const DEFAULT_NS_SEPARATOR = "|:|"
 
 /**
  * ALPHA API: This API is still in development and may change at any time.
@@ -170,6 +170,11 @@ export class SecureStorage extends BaseStorage {
     const value = JSON.stringify(rawValue)
     const boxBase64 = await this.encrypt(value)
     return await this.rawSet(nsKey, boxBase64)
+  }
+
+  remove = async (key: string) => {
+    const nsKey = this.getNamespacedKey(key)
+    return await this.rawRemove(nsKey)
   }
 
   protected parseValue = async (boxBase64: string) => {


### PR DESCRIPTION
## Details

fixes: PlasmoHQ/storage#31

This PR addresses an issue in the `@plasmo/storage` where the remove method does not handle namespaces correctly. It also introduces new test cases that cover basic CRUD operations.

Changes:
- Updated the `Storage` class in the `@plasmo/storage` package to correctly handle namespaces when performing the `remove` operation.
- Added new test cases that utilize a modified mock to verify basic CRUD operations, ensuring proper functionality and increasing test coverage.

### Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/PlasmoHQ/plasmo/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] I checked the [current PR](https://github.com/PlasmoHQ/plasmo/pulls) for duplication.

## Contacts

- (OPTIONAL) Discord ID:

If your PR is accepted, we will award you with the `Contributor` role on Discord server.

To join the server, visit: https://www.plasmo.com/s/d
