### PR TITLE
fix: storage.get with chrome-mv2 pify must set errorFirst to false

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,7 @@ export abstract class BaseStorage {
 
         if (isChromeBelow100()) {
           this.#primaryClient = pify(this.#extStorageEngine[this.area], {
+            errorFirst: false,
             exclude: ["getBytesInUse"]
           })
         } else {


### PR DESCRIPTION
errorFirst
Type: boolean
Default: true

Whether the callback has an error as the first argument. You'll want to set this to false if you're dealing with an API that doesn't have an error as the first argument, like fs.exists(), some browser APIs, Chrome Extension APIs, etc.

if errorFist is not set to false, storage not work with chrome-mv2