### PR TITLE
fix: storage pify errorFirst

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,8 @@ export abstract class BaseStorage {
 
         if (isChromeBelow100()) {
           this.#primaryClient = pify(this.#extStorageEngine[this.area], {
-            exclude: ["getBytesInUse"]
+            exclude: ["getBytesInUse"],
+            errorFirst: false
           })
         } else {
           this.#primaryClient = this.#extStorageEngine[this.area]


### PR DESCRIPTION
It turns out that https://github.com/PlasmoHQ/storage/pull/38 was not enough.

I kept getting the result (`{}` in that screenshot) rejected when using `plasmoStorage.get`:

<img width="222" alt="CleanShot 2023-07-25 at 11 51 09@2x" src="https://github.com/PlasmoHQ/storage/assets/611271/90fe8194-e1e6-46a2-b004-9ccd0ab56181">

While using `chrome.storage.local.get` directly would work fine.

https://developer.chrome.com/docs/extensions/reference/storage/#method-StorageArea-get documents the callback as `(items: object) => void`, no error is passed.

https://github.com/sindresorhus/pify#errorfirst is false by default, and mentions:
> You'll want to set this to false if you're dealing with an API that doesn't have an error as the first argument, like fs.exists(), some browser APIs, Chrome Extension APIs, etc.