### PR TITLE
feat: make the storage key reactive

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,7 +4,7 @@
  * This module share storage between chrome storage and local storage.
  */
 import { beforeEach, describe, expect, jest, test } from "@jest/globals"
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook } from "@testing-library/react"
 
 import type { StorageWatchEventListener } from "~index"
 


### PR DESCRIPTION
Fixes #36 by making the useStorage `key` parameter reactive.

I added a useRef to track the current `renderValue` within the hook. This avoids us from adding dependencies to some of the callbacks and so it prevents needless un-mounting and re-mounting of the storage.

I added a test to ensure the storage unmounts and re-mounts properly when the key changes.

Note: this only makes the string `key` reactive, _not_ a custom Storage paramater that's passed in. If someone wants to switch between different Storages (sync and local, for example) using the same hook, it won't happen automatically since the Storage parameter is not reactive (this might be another PR if I can figure out how to make it happen)