### PR TITLE
small hydration improvements

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { BaseStorage, Storage, type StorageCallbackMap } from "./index"
 
-type Setter<T> = ((v?: T, isHydrating?: boolean) => T) | T
+type Setter<T> = ((v?: T, isHydrated?: boolean) => T) | T
 
 /**
  * isPublic: If true, the value will be synced with web API Storage

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -92,7 +92,9 @@ export const useStorage = <T = any>(rawKey: RawKey, onInit?: Setter<T>) => {
     return () => {
       isMounted.current = false
       storageRef.current.unwatch(watchConfig)
-      if (onInit instanceof Function) setRenderValue(onInit)
+      if (onInit instanceof Function) {
+        setRenderValue(onInit)
+      }
     }
   }, [key, persistValue])
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -92,6 +92,7 @@ export const useStorage = <T = any>(rawKey: RawKey, onInit?: Setter<T>) => {
     return () => {
       isMounted.current = false
       storageRef.current.unwatch(watchConfig)
+      if (onInit instanceof Function) setRenderValue(onInit)
     }
   }, [key, persistValue])
 


### PR DESCRIPTION
This implements the small changes discussed in #46.

If the `onInit` parameter passed to the hook is a function, it is run to reset the render value when the storage unmounts. This allows the advanced use case of handling the loading/hydration state in the `onInit` function.

I also renamed the boolean parameter to `isHydrated`, which better describes the state it represents. This is purely a documentation change.