### PR TITLE
Fix hook value type having `undefined` even when with default value

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -30,7 +30,7 @@ export const useStorage = <T = any>(rawKey: RawKey, onInit?: Setter<T>) => {
   const key = isObjectKey ? rawKey.key : rawKey
 
   // Render state
-  const [renderValue, setRenderValue] = useState<T | undefined>(onInit)
+  const [renderValue, setRenderValue] = useState<T>(onInit)
 
   // Use to ensure we don't set render state after unmounted
   const isMounted = useRef(false)


### PR DESCRIPTION
The recent pull request #49 modified the value type for the value element of `useStorage`s return type. With that change the value type includes `undefined` even when a default value is supplied (via the second parameter of the hook).

To clarity,
The current behaviour after that pull request:
```ts
const [theme, setTheme] = useStorage('theme', 'system');
//       ^? string | undefined
// should not include `undefined` when default value is passed
```
The expected behaviour:
```ts
const [theme, setTheme] = useStorage('theme', 'system');
//       ^? string
// because of the default, the value always exists even before it has grabbed the actual value from storage
```