### PR TITLE
fix type of useStorage

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -24,7 +24,30 @@ export type RawKey =
  * @param onInit  If it is a function, the returned value will be rendered and persisted. If it is a static value, it will only be rendered, not persisted
  * @returns
  */
-export const useStorage = <T = any>(rawKey: RawKey, onInit?: Setter<T>) => {
+export function useStorage<T = any>(
+  rawKey: RawKey,
+  onInit: Setter<T>
+): [
+  T,
+  (setter: Setter<T>) => Promise<void>,
+  {
+    readonly setRenderValue: React.Dispatch<React.SetStateAction<T>>
+    readonly setStoreValue: (v: T) => Promise<null>
+    readonly remove: () => void
+  }
+]
+export function useStorage<T = any>(
+  rawKey: RawKey
+): [
+  T | undefined,
+  (setter: Setter<T>) => Promise<void>,
+  {
+    readonly setRenderValue: React.Dispatch<React.SetStateAction<T | undefined>>
+    readonly setStoreValue: (v?: T) => Promise<null>
+    readonly remove: () => void
+  }
+]
+export function useStorage<T = any>(rawKey: RawKey, onInit?: Setter<T>) {
   const isObjectKey = typeof rawKey === "object"
 
   const key = isObjectKey ? rawKey.key : rawKey


### PR DESCRIPTION
Firstly, thank you for the awesome product!

This changes is related: https://github.com/PlasmoHQ/storage/pull/49, https://github.com/PlasmoHQ/storage/pull/52.
To use overload, we achieve the following result.

```
const [a] = useStorage<string>("key1")
//     ^ string | undefined
const [b] = useStorage("key2", "init")
//     ^ string
const [c] = useStorage("key3", (v: string) => v === undefined ? "init" : v)
//     ^ string
```

I'm looking forward to your feedback or any suggestions you might have.
