### PR TITLE
fix(useStorage): isLoading becoming false before returning value

### DIFF
--- a/src/hook.ts
+++ b/src/hook.ts
@@ -109,13 +109,13 @@ export function useStorage<T = any>(rawKey: RawKey, onInit?: Setter<T>) {
       if (onInit instanceof Function) {
         const initValue = onInit?.(v, true)
         if (initValue !== undefined) {
-          persistValue(initValue)
+          return persistValue(initValue)
         }
       } else {
         setRenderValue(v !== undefined ? v : onInit)
       }
-      setIsLoading(false)
     })
+    .finally(() => setIsLoading(false))
 
     return () => {
       isMounted.current = false

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -105,17 +105,22 @@ export function useStorage<T = any>(rawKey: RawKey, onInit?: Setter<T>) {
 
     storageRef.current.watch(watchConfig)
 
-    storageRef.current.get<T>(key)?.then((v) => {
+    const initializeStorage = async () => {
+      const storedValue = await storageRef.current.get<T>(key)
+
       if (onInit instanceof Function) {
-        const initValue = onInit?.(v, true)
+        const initValue = onInit?.(storedValue, true)
         if (initValue !== undefined) {
-          return persistValue(initValue)
+          await persistValue(initValue)
         }
       } else {
-        setRenderValue(v !== undefined ? v : onInit)
+        setRenderValue(storedValue !== undefined ? storedValue : onInit)
       }
-    })
-    .finally(() => setIsLoading(false))
+
+      setIsLoading(false)
+    }
+
+    initializeStorage()
 
     return () => {
       isMounted.current = false


### PR DESCRIPTION
When using the `useStorage` hook with the `isLoading` value, I ran into issues because the hook would return `isLoading` as **false** before returning a value even if it's present in storage. This fix has been working for me which ensures the value is returned before `isLoading` becomes **false**.

(I should also mention that the current `isLoading` solution works when I'm using smaller values like strings but not when I'm using objects or lists)

Before:
<img width="292" alt="before" src="https://github.com/user-attachments/assets/49efd95b-4be8-40df-8cfd-23e3f292bc48">
After:
<img width="280" alt="after" src="https://github.com/user-attachments/assets/3da5627c-88b7-4b5a-b8a3-5f1b53b68b10">
